### PR TITLE
Simplify message printing in samples

### DIFF
--- a/src/hello_claude.py
+++ b/src/hello_claude.py
@@ -49,9 +49,7 @@ def main() -> int:
     )
 
     for block in message.content:
-        text = getattr(block, "text", None)
-        if text:
-            print(text)
+        print(block.text)
 
     print(f"\n[usage] input={message.usage.input_tokens} output={message.usage.output_tokens}")
     return 0

--- a/src/hello_claude_apikey.py
+++ b/src/hello_claude_apikey.py
@@ -39,9 +39,7 @@ def main() -> int:
         messages=[{"role": "user", "content": "What are 3 things to visit in Seattle?"}],
     )
     for block in msg.content:
-        text = getattr(block, "text", None)
-        if text:
-            print(text)
+        print(block.text)
     print(f"\n[usage] input={msg.usage.input_tokens} output={msg.usage.output_tokens}")
     return 0
 

--- a/src/hello_claude_token_refresh.py
+++ b/src/hello_claude_token_refresh.py
@@ -79,9 +79,7 @@ def main() -> int:
         messages=[{"role": "user", "content": "What are 3 things to visit in Seattle?"}],
     )
     for block in msg.content:
-        text = getattr(block, "text", None)
-        if text:
-            print(text)
+        print(block.text)
     print(f"\n[usage] input={msg.usage.input_tokens} output={msg.usage.output_tokens}")
     return 0
 


### PR DESCRIPTION
Replace getattr(block, 'text', None) loops with plain print(block.text) in the three single-shot samples.

The Messages API only returns text blocks for these prompts, so the guarded access added noise without value. Matches the style of the official Foundry/Anthropic quickstart samples.

### Files
- src/hello_claude.py
- src/hello_claude_apikey.py
- src/hello_claude_token_refresh.py

### Verified

`
python src/hello_claude.py
`
returns the expected Seattle response, no errors.