### PR TITLE
Document Anthropic terms auto-acceptance and prompt user to set attestation fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ Two equivalent IaC variants ship side-by-side. Pick one and `azd up`:
 
 The Python sample under [`src/`](./src/) works against either.
 
+> [!IMPORTANT]
+> **By running `azd up` you accept Anthropic's commercial terms for Claude.**
+>
+> The Terraform and Bicep in this template both send a `modelProviderData` block (`organizationName`, `countryCode`, `industry`) with each Claude deployment. The Cognitive Services RP uses that block to **auto-sign the Azure Marketplace offer for Anthropic Claude on your behalf** — no manual click-through. Before deploying, please:
+>
+> 1. Read the [Anthropic Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms) and the [Anthropic Usage Policy](https://www.anthropic.com/legal/aup) (formerly the Acceptable Use Policy). These govern your use of Claude via Microsoft Foundry, in addition to the [Microsoft Product Terms](https://www.microsoft.com/licensing/terms/) for Azure.
+> 2. **Update the three attestation fields below so they accurately describe your organization** — see the highlighted rows in [Configuration](#configuration):
+>    - `CLAUDE_ORGANIZATION_NAME` (no default — required)
+>    - `CLAUDE_COUNTRY_CODE` (default `US`)
+>    - `CLAUDE_INDUSTRY` (default `technology`)
+>
+>    These values are sent to Anthropic on every request and are part of your acceptance — they should match the real legal entity, country of operation, and industry that will use the model.
+> 3. Confirm your Azure subscription is [eligible to deploy Anthropic models in Foundry](https://learn.microsoft.com/azure/ai-foundry/foundry-models/how-to/use-foundry-models-claude#prerequisites).
+
 > **Looking for something more advanced?** Jump to: [Claude Code post-deploy setup](#claude-code-post-deploy-setup) · [auto-refreshing Entra ID tokens for long-running processes](#advanced-long-running-processes-auto-refreshing-the-entra-id-token) · [preprovision preflight](#preprovision-preflight-marketplace-catalog--quota) · [check Claude quota & capacity programmatically](#advanced-check-claude-quota--capacity-programmatically).
 
 ## Prerequisites
@@ -34,6 +48,12 @@ azd env new my-claude   # answer 'y' when asked "Set new environment ... as defa
                         # (if you already created the env, run `azd env select my-claude`)
 azd env set CLAUDE_ORGANIZATION_NAME "Contoso"
 azd env set AZURE_LOCATION "swedencentral"
+
+# Anthropic model-provider attestation (sent to Anthropic with every request,
+# part of accepting their commercial terms — see the IMPORTANT note above).
+# Defaults are US / technology. Override if your org is not US-based or not tech:
+# azd env set CLAUDE_COUNTRY_CODE "GB"
+# azd env set CLAUDE_INDUSTRY     "finance"
 
 # Pick which Claude families to deploy. Empty = skip that family.
 # Defaults below = all three; comment out any line to deploy a subset.
@@ -95,9 +115,13 @@ python src/hello_claude_apikey.py
 
 ## Configuration
 
+Rows marked **Attest** below are the three `modelProviderData` fields sent to Anthropic and used by the marketplace RP to auto-sign the [Anthropic Commercial Terms](https://www.anthropic.com/legal/commercial-terms) on your behalf — see the [IMPORTANT note at the top of this README](#claude-on-microsoft-foundry--starter). Set them to match your real organization.
+
 | Var | Required | Default | Notes |
 |---|---|---|---|
-| `CLAUDE_ORGANIZATION_NAME` | yes | — | Surfaced via `modelProviderData` |
+| `CLAUDE_ORGANIZATION_NAME` | **Attest** (yes) | — | **Legal entity name** sent to Anthropic via `modelProviderData`. |
+| `CLAUDE_COUNTRY_CODE` | **Attest** | `US` | 2-letter ISO. Country your organization operates from. |
+| `CLAUDE_INDUSTRY` | **Attest** | `technology` | **lowercase**: `technology`, `finance`, `healthcare`, `education`, `retail`, `manufacturing`, `government`, `media`, `other` |
 | `AZURE_LOCATION` | yes | — | `eastus2` / `swedencentral` (all 3 families) / `westus2` (sonnet + opus) |
 | `CLAUDE_HAIKU_MODEL` | no | *(empty)* | Haiku family model id (e.g. `claude-haiku-4-5`). Empty = skip. |
 | `CLAUDE_SONNET_MODEL` | no | *(empty)* | Sonnet family model id (e.g. `claude-sonnet-4-6`). Empty = skip. |
@@ -105,8 +129,6 @@ python src/hello_claude_apikey.py
 | `CLAUDE_HAIKU_CAPACITY` | no | `25` | Haiku TPM / 1000 |
 | `CLAUDE_SONNET_CAPACITY` | no | `25` | Sonnet TPM / 1000 |
 | `CLAUDE_OPUS_CAPACITY` | no | `25` | Opus TPM / 1000 |
-| `CLAUDE_COUNTRY_CODE` | no | `US` | 2-letter ISO |
-| `CLAUDE_INDUSTRY` | no | `technology` | **lowercase**: `technology`, `finance`, `healthcare`, `education`, `retail`, `manufacturing`, `government`, `media`, `other` |
 | `CLAUDE_MODEL_VERSION` | no | `1` | Applies to all deployed families. |
 | `CLAUDE_MODEL_NAME` | no | `claude-sonnet-4-6` | **Legacy.** Only used when all three `CLAUDE_*_MODEL` vars are empty (single-deployment fallback). |
 | `CLAUDE_MODEL_CAPACITY` | no | `25` | **Legacy.** Capacity for the legacy single-deployment fallback. |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,27 @@ The Python sample under [`src/`](./src/) works against either.
 >
 >    These values are sent to Anthropic on every request and are part of your acceptance — they should match the real legal entity, country of operation, and industry that will use the model.
 > 3. Confirm your Azure subscription is [eligible to deploy Anthropic models in Foundry](https://learn.microsoft.com/azure/ai-foundry/foundry-models/how-to/use-foundry-models-claude#prerequisites).
+>
+> <details>
+> <summary>Preview the dialog Foundry would show on the manual path, and audit acceptance after <code>azd up</code></summary>
+>
+> The exact "Agree and proceed" dialog the Azure portal renders for a Claude SKU is generated live from the Marketplace offer metadata (Microsoft template + publisher-supplied links). It can change without notice, so this README does not snapshot its text — instead, open the live marketplace listing for the SKU you plan to deploy:
+>
+> - Sonnet 4.6 — <https://azuremarketplace.microsoft.com/en-us/marketplace/apps/anthropic.anthropic-claude-sonnet-4-6-offer>
+> - Opus 4.6 — <https://azuremarketplace.microsoft.com/en-us/marketplace/apps/anthropic.anthropic-claude-opus-4-6-offer>
+> - Haiku 4.5 — <https://azuremarketplace.microsoft.com/en-us/marketplace/apps/anthropic.anthropic-claude-haiku-4-5-offer>
+> - All Anthropic offers — <https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=anthropic>
+>
+> After `azd up`, you can audit the auto-signed marketplace agreement record from the CLI (returns metadata only — `accepted`, `signature`, signed-by, date, `licenseTextLink` — not the dialog text):
+>
+> ```bash
+> az term show \
+>   --publisher anthropic \
+>   --product anthropic-claude-sonnet-4-6-offer \
+>   --plan <plan-name>
+> ```
+>
+> </details>
 
 > **Looking for something more advanced?** Jump to: [Claude Code post-deploy setup](#claude-code-post-deploy-setup) · [auto-refreshing Entra ID tokens for long-running processes](#advanced-long-running-processes-auto-refreshing-the-entra-id-token) · [preprovision preflight](#preprovision-preflight-marketplace-catalog--quota) · [check Claude quota & capacity programmatically](#advanced-check-claude-quota--capacity-programmatically).
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ The Python sample under [`src/`](./src/) works against either.
 >
 > The Terraform and Bicep in this template both send a `modelProviderData` block (`organizationName`, `countryCode`, `industry`) with each Claude deployment. The Cognitive Services RP uses that block to **auto-sign the Azure Marketplace offer for Anthropic Claude on your behalf** — no manual click-through. Before deploying, please:
 >
-> 1. Read the [Anthropic Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms) and the [Anthropic Usage Policy](https://www.anthropic.com/legal/aup) (formerly the Acceptable Use Policy). These govern your use of Claude via Microsoft Foundry, in addition to the [Microsoft Product Terms](https://www.microsoft.com/licensing/terms/) for Azure.
+> 1. Read the legal docs that govern your use of Claude via Microsoft Foundry:
+>    - [Anthropic Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms) — the master agreement for business / enterprise use (Foundry requires an Enterprise or MCA-E subscription).
+>    - [Anthropic Usage Policy](https://www.anthropic.com/legal/aup) (also called the Acceptable Use Policy / AUP) — incorporated by reference into the Commercial Terms and the doc Microsoft Foundry's own [Responsible AI guidance](https://learn.microsoft.com/azure/ai-foundry/foundry-models/how-to/use-foundry-models-claude#responsible-ai-considerations) points to.
+>    - [Anthropic Supported Regions Policy](https://aka.ms/supported_anthropic_regions) — also incorporated by reference; controls which regions are eligible.
+>    - [Microsoft Product Terms](https://www.microsoft.com/licensing/terms/) for Azure.
 > 2. **Update the three attestation fields below so they accurately describe your organization** — see the highlighted rows in [Configuration](#configuration):
 >    - `CLAUDE_ORGANIZATION_NAME` (no default — required)
 >    - `CLAUDE_COUNTRY_CODE` (default `US`)
@@ -115,7 +119,7 @@ python src/hello_claude_apikey.py
 
 ## Configuration
 
-Rows marked **Attest** below are the three `modelProviderData` fields sent to Anthropic and used by the marketplace RP to auto-sign the [Anthropic Commercial Terms](https://www.anthropic.com/legal/commercial-terms) on your behalf — see the [IMPORTANT note at the top of this README](#claude-on-microsoft-foundry--starter). Set them to match your real organization.
+Rows marked **Attest** below are the three `modelProviderData` fields sent to Anthropic and used by the marketplace RP to auto-sign the [Anthropic Commercial Terms](https://www.anthropic.com/legal/commercial-terms) (which incorporate the [Usage Policy](https://www.anthropic.com/legal/aup) and [Supported Regions Policy](https://aka.ms/supported_anthropic_regions) by reference) on your behalf — see the [IMPORTANT note at the top of this README](#claude-on-microsoft-foundry--starter). Set them to match your real organization.
 
 | Var | Required | Default | Notes |
 |---|---|---|---|

--- a/infra-bicep/infra/main.bicep
+++ b/infra-bicep/infra/main.bicep
@@ -1,6 +1,12 @@
 // ============================================================================
 // Microsoft Foundry + Claude — Bicep (azd-driven)
 // ----------------------------------------------------------------------------
+// IMPORTANT: Deploying this Bicep auto-accepts the Anthropic Marketplace
+// offer terms via the `modelProviderData` block on each deployment. Review
+// https://www.anthropic.com/legal/commercial-terms and the IMPORTANT note in
+// README.md before running `azd up`. Set `claudeOrganizationName`,
+// `claudeCountryCode`, `claudeIndustry` to match your real organization.
+// ----------------------------------------------------------------------------
 // `modelProviderData` is REQUIRED for Claude deployments. `industry`
 // MUST be lowercase to match the Foundry portal dropdown.
 // `allowProjectManagement = true` is required to create projects under the

--- a/infra-terraform/infra/main.tf
+++ b/infra-terraform/infra/main.tf
@@ -1,6 +1,12 @@
 # ============================================================================
 # Microsoft Foundry + Claude — Terraform (azd-driven)
 # ----------------------------------------------------------------------------
+# IMPORTANT: Applying this Terraform auto-accepts the Anthropic Marketplace
+# offer terms via the `modelProviderData` block on each deployment. Review
+# https://www.anthropic.com/legal/commercial-terms and the IMPORTANT note in
+# README.md before running `azd up`. Set `claude_organization_name`,
+# `claude_country_code`, `claude_industry` to match your real organization.
+# ----------------------------------------------------------------------------
 # - Foundry account is created via `azapi_resource` so we can set
 #   `allowProjectManagement = true` (required for child projects, not yet
 #   exposed by `azurerm_cognitive_account`).


### PR DESCRIPTION
## What

Adds clear, user-facing disclosure that running this template **auto-accepts the Anthropic Marketplace offer terms** via the `modelProviderData` block on each Claude deployment, and asks the user to fill in the three attestation fields with values that match their actual organization.

## Why

The Cognitive Services RP uses the `modelProviderData` block (`organizationName`, `countryCode`, `industry`) attached to each Claude deployment to silently accept the Azure Marketplace offer for Anthropic Claude on the user's behalf — there is no manual click-through, and the template previously did not document that this is happening. The three attestation fields also shipped with defaults (`US` / `technology`) that many users would not realize they should customize.

This PR makes the auto-acceptance behavior obvious, links the user to the canonical legal docs, and surfaces the three fields they should set correctly.

## Changes

### `README.md`
- New top-of-README `> [!IMPORTANT]` callout (right under the IaC variants table) that:
  - States plainly that `azd up` accepts Anthropic's commercial terms.
  - Explains the `modelProviderData` auto-signing mechanism in one sentence.
  - Links to:
    - [Anthropic Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms)
    - [Anthropic Usage Policy](https://www.anthropic.com/legal/aup) (formerly AUP)
    - [Microsoft Product Terms](https://www.microsoft.com/licensing/terms/)
    - The existing Foundry eligibility prereq doc
  - Asks the user to update `CLAUDE_ORGANIZATION_NAME`, `CLAUDE_COUNTRY_CODE`, `CLAUDE_INDUSTRY` to match their real legal entity, country of operation, and industry before deploying.
- Quickstart now has an inline reminder right after `CLAUDE_ORGANIZATION_NAME` / `AZURE_LOCATION` with commented examples for overriding country/industry.
- Configuration table:
  - Promotes the three attestation rows to the top.
  - Marks their Required column as **Attest** to make the special status visible.
  - Adds a one-line intro pointing back to the IMPORTANT callout.
  - Removes the legacy duplicate rows for country/industry from their old positions in the table.

### `infra-terraform/infra/main.tf` & `infra-bicep/infra/main.bicep`
- Each entry point gains a 5-line IMPORTANT header noting:
  - Applying this IaC auto-accepts the Anthropic Marketplace offer.
  - Link to the commercial terms URL.
  - Pointer to the README's IMPORTANT note.
  - Reminder to set the org / country / industry variables to match the user's real organization.
- Covers users who jump straight to the code without reading the README.

## Non-changes

- **No functional change.** Defaults are not modified. Behavior of `azd up` is unchanged. This is documentation-only plus comment headers.

## Verification

- README, `main.tf`, `main.bicep` all clean of lint/syntax errors after the edit.
- Markdown alert syntax (`> [!IMPORTANT]`) is GitHub's standard alert format and renders as a colored callout box on the public repo view.
- All linked URLs are canonical:
  - `https://www.anthropic.com/legal/commercial-terms`
  - `https://www.anthropic.com/legal/aup`
  - `https://www.microsoft.com/licensing/terms/`
