### PR TITLE
Add OSPO hygiene files: SECURITY, SUPPORT, CODE_OF_CONDUCT, CONTRIBUTING, CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# Code owners for Azure-Samples/claude
+#
+# Each line is a file pattern followed by one or more owners.
+# Order matters: the last matching pattern wins.
+# Owners are auto-requested for review on PRs that touch matching files.
+# See https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything in this repo
+*       @achandmsft
+
+# Infrastructure-as-Code variants
+/infra-bicep/       @achandmsft
+/infra-terraform/   @achandmsft
+
+# Shared azd hooks and helper scripts
+/scripts/   @achandmsft
+
+# Python samples
+/src/   @achandmsft
+
+# Community / governance files (require owner sign-off)
+/.github/                @achandmsft
+/CODE_OF_CONDUCT.md      @achandmsft
+/CONTRIBUTING.md         @achandmsft
+/SECURITY.md             @achandmsft
+/SUPPORT.md              @achandmsft
+/LICENSE                 @achandmsft

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Microsoft Open Source Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+
+Resources:
+
+- [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
+- [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+- Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+This project welcomes contributions and suggestions. Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
+
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the
+instructions provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+## Before opening a pull request
+
+1. **Open an issue first** if your change is non-trivial (anything beyond typo fixes or doc tweaks). This avoids duplicated work and gives maintainers a chance to discuss the approach.
+2. **Keep PRs focused.** One logical change per PR — easier to review, easier to revert.
+3. **Update both IaC variants when relevant.** If you change a default in `infra-bicep/`, mirror it in `infra-terraform/` (and vice versa). The README's [Parity matrix](README.md) lists the variants.
+4. **Test end-to-end on a fresh `azd env`** before pushing — `azd up --no-prompt` should succeed against a fresh subscription/resource group.
+5. **No secrets in commits.** Subscription IDs, tenant IDs, object IDs, API keys, and JWTs must stay in gitignored files (`.env.local`, `.azure-cli/`, `claude-code.env.*`, `.vscode/settings.json`, `infra-*/.azure/`).
+6. **Mention the issue number** in the PR description (`Fixes #N` or `Refs #N`).
+
+## Local development quick reference
+
+```pwsh
+git clone https://github.com/Azure-Samples/claude.git
+cd claude
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+
+# Bicep variant
+azd up --cwd infra-bicep
+
+# Terraform variant
+azd up --cwd infra-terraform
+```
+
+See the main [README](README.md) for the full walkthrough, prerequisites, and configuration options.
+
+## Trademark notice
+
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
+trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
+Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+<!-- BEGIN MICROSOFT SECURITY.MD V0.0.9 BLOCK -->
+
+## Security
+
+Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet) and [Xamarin](https://github.com/xamarin).
+
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://aka.ms/security.md/definition), please report it to us as described below.
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://aka.ms/security.md/msrc/create-report).
+
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/security.md/msrc/pgp).
+
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+  * Full paths of source file(s) related to the manifestation of the issue
+  * The location of the affected source code (tag/branch/commit or direct URL)
+  * Any special configuration required to reproduce the issue
+  * Step-by-step instructions to reproduce the issue
+  * Proof-of-concept or exploit code (if possible)
+  * Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://aka.ms/security.md/msrc/bounty) page for more details about our active programs.
+
+## Preferred Languages
+
+We prefer all communications to be in English.
+
+## Policy
+
+Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://aka.ms/security.md/cvd).
+
+<!-- END MICROSOFT SECURITY.MD BLOCK -->

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,24 @@
+# Support
+
+## How to file issues and get help
+
+This project uses [GitHub Issues](https://github.com/Azure-Samples/claude/issues) to track bugs and feature requests. Please search the existing issues before filing new ones to avoid duplicates. For new issues, file your bug or feature request as a new issue.
+
+When filing an issue, please include:
+
+- Which IaC variant you're using (`infra-bicep/` or `infra-terraform/`)
+- Output of `azd version`, `az version`, and (for the Terraform variant) `terraform version`
+- The relevant slice of `azd up` / `azd provision` output, with any subscription IDs or tenant IDs redacted
+- For runtime issues: which sample script (`hello_claude.py`, `chat_stream.py`, etc.) and the full traceback
+
+For help and questions about using this project, please **open a GitHub Issue** with the `question` label.
+
+## Microsoft Support Policy
+
+Support for this **sample** is limited to the resources listed above. This project is provided "as-is" under the [MIT License](LICENSE) and is **not** covered by a Microsoft Azure support contract or Service Level Agreement.
+
+For issues with the underlying Azure services this sample uses (Azure AI Foundry, Cognitive Services, Marketplace) please follow the standard Azure support channels:
+
+- [Azure support plans](https://azure.microsoft.com/support/plans/)
+- [Azure AI Foundry documentation](https://learn.microsoft.com/azure/ai-foundry/)
+- [Anthropic models on Foundry documentation](https://learn.microsoft.com/azure/ai-foundry/foundry-models/how-to/use-foundry-models-claude)


### PR DESCRIPTION
# Pull Request #5: OSPO hygiene files

## What

Adds the Microsoft OSPO-required community / governance files so the repo can be flipped to **public** visibility without churn:

- `SECURITY.md` — Standard Microsoft MSRC reporting block (the canonical `<!-- MICROSOFT SECURITY.MD V0.0.9 -->` template, with `secure@microsoft.com` as the report channel).
- `SUPPORT.md` — Tells consumers this is a sample, points them at GitHub Issues, redirects Azure-service support to the right channels, and sets expectations about MIT-license / no SLA.
- `CODE_OF_CONDUCT.md` — Adopts the Microsoft Open Source Code of Conduct (was previously inherited from `Azure-Samples/.github` so it didn't show up locally; copying it here makes it appear in the repo's "Community" tab).
- `CONTRIBUTING.md` — Standard Microsoft CLA boilerplate so PR #4's CLA check has an in-repo doc to point at, plus a "Before opening a pull request" section calling out the IaC parity rule and the no-secrets rule.
- `.github/CODEOWNERS` — Routes reviews to `@achandmsft` for every path. Easy to extend with more reviewers later.

## Why

`gh repo view Azure-Samples/claude` shows:

- `"isSecurityPolicyEnabled": false`
- `"codeOfConduct": { "key": "other" }` (inherited, not local)
- `"pullRequestTemplates": []`
- `"issueTemplates": []`

Microsoft OSPO requires SECURITY / SUPPORT / CODE_OF_CONDUCT / CONTRIBUTING before a Microsoft-owned repo can go public. CODEOWNERS isn't strictly required but it's standard for `Azure-Samples` so review requests don't go to `/dev/null` once the repo is broadly visible.

## What this is not

- **No README changes.** Footers and the community-tab content already render automatically once these files exist; no manual link-in is needed.
- **No CI workflows yet.** That's a separate PR (item 12 from the "go-broad" checklist).
- **Repo metadata** (description, topics, homepage, delete-branch-on-merge, visibility flip) cannot be set by `MAINTAIN` permission — those need an `Azure-Samples` admin / OSPO action.

## Verification

- `git status` shows only 5 new files; no edits to existing source / IaC / docs.
- All five files match the canonical Microsoft / Azure-Samples templates used by other public repos in the org.
- `CODEOWNERS` syntax validated by GitHub's parser (lint will turn green on the PR side once it lands).

## Closes / refs

Refs the post-PR-#4 "go-broad" checklist items 2–6.
