### PR TITLE
Add CI workflow, Dependabot config, issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+name: Bug report
+description: Something in this sample is not working as documented.
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: variant
+    attributes:
+      label: IaC variant
+      description: Which variant did you deploy?
+      options:
+        - Bicep (infra-bicep)
+        - Terraform (infra-terraform)
+        - N/A — sample script / docs issue
+    validations:
+      required: true
+  - type: input
+    id: region
+    attributes:
+      label: Azure region
+      placeholder: eastus2, swedencentral, westus2
+    validations:
+      required: true
+  - type: input
+    id: model
+    attributes:
+      label: Claude model + family
+      placeholder: claude-sonnet-4-6 / claude-haiku-4-5 / claude-opus-4-7
+    validations:
+      required: true
+  - type: textarea
+    id: tool-versions
+    attributes:
+      label: Tool versions
+      description: Run `azd version`, `az version`, `terraform version` (if applicable), `python --version`. Paste the output here.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Be precise — what env vars you set, the exact commands, etc.
+      placeholder: |
+        1. azd env new ...
+        2. azd env set ...
+        3. azd up
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior + logs
+      description: Paste relevant error output. **Redact subscription IDs, tenant IDs, and object IDs.**
+      render: shell
+    validations:
+      required: true
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I checked existing issues and didn't find a duplicate.
+          required: true
+        - label: I redacted all subscription / tenant / object IDs and any secrets from logs.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://msrc.microsoft.com/create-report
+    about: Please report security issues to MSRC, NOT in public GitHub issues. See SECURITY.md.
+  - name: Microsoft Foundry / Anthropic Claude docs
+    url: https://learn.microsoft.com/azure/ai-foundry/foundry-models/how-to/use-foundry-models-claude
+    about: Official Foundry docs for Claude models — covers regions, prerequisites, RBAC, RAI.
+  - name: Anthropic Claude SDK docs
+    url: https://docs.claude.com/
+    about: Official Claude SDK docs (Python, TypeScript, etc.).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest an enhancement or new capability for this sample.
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Be concrete — what does the sample fail to do today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Where does this change land?
+      multiple: true
+      options:
+        - Bicep IaC (infra-bicep)
+        - Terraform IaC (infra-terraform)
+        - Python samples (src/)
+        - Scripts / hooks (scripts/)
+        - README / docs
+        - CI / GitHub config

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!-- Thanks for opening a PR! Please fill out the sections below. -->
+
+## What
+
+<!-- One-line summary of the change. -->
+
+## Why
+
+<!-- Link an issue (e.g., `Fixes #123`) or explain the motivation. -->
+
+## How
+
+<!-- Brief description of the approach. Skip if obvious from the diff. -->
+
+## Verification
+
+<!-- How was this tested? At minimum, mention which IaC variant(s) and sub. -->
+
+- [ ] `azd up` succeeded end-to-end on a fresh env (Bicep)
+- [ ] `azd up` succeeded end-to-end on a fresh env (Terraform)
+- [ ] `python src/hello_claude.py` returned a live model response
+- [ ] N/A — docs-only / CI-only change
+
+## Checklist
+
+- [ ] Mirrored the change across **both** `infra-bicep/` and `infra-terraform/` (if applicable)
+- [ ] No secrets / subscription IDs / tenant IDs / object IDs in commits, comments, or PR body
+- [ ] README updated if user-facing behavior changed
+- [ ] Conventional one logical change per PR

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  # Python sample dependencies
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "python"]
+    commit-message:
+      prefix: pip
+      include: scope
+
+  # GitHub Actions workflows
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "github-actions"]
+    commit-message:
+      prefix: gha
+      include: scope
+
+  # Terraform providers (azapi, azurerm, random)
+  - package-ecosystem: terraform
+    directory: /infra-terraform/infra
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "terraform"]
+    commit-message:
+      prefix: tf
+      include: scope

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,96 @@
+name: validate
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bicep:
+    name: Bicep build + lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Bicep CLI
+        run: |
+          curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64
+          chmod +x bicep
+          sudo mv bicep /usr/local/bin/bicep
+          bicep --version
+      - name: bicep build (main.bicep)
+        run: bicep build infra-bicep/infra/main.bicep --outfile /tmp/main.json
+      - name: bicep build (foundry.bicep)
+        run: bicep build infra-bicep/infra/foundry.bicep --outfile /tmp/foundry.json
+      - name: bicep lint
+        run: |
+          bicep lint infra-bicep/infra/main.bicep
+          bicep lint infra-bicep/infra/foundry.bicep
+
+  terraform:
+    name: Terraform fmt + validate
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra-terraform/infra
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.6.0"
+          terraform_wrapper: false
+      - name: terraform fmt -check
+        run: terraform fmt -check -recursive
+      - name: terraform init (backend=false)
+        run: terraform init -backend=false
+      - name: terraform validate
+        run: terraform validate -no-color
+
+  python:
+    name: Python compile + import check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install runtime deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Byte-compile all sample scripts
+        run: python -m compileall -q src/
+
+  shell:
+    name: Shellcheck + PSScriptAnalyzer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run shellcheck on *.sh
+        run: |
+          mapfile -d '' files < <(git ls-files -z '*.sh')
+          if [ "${#files[@]}" -eq 0 ]; then echo "No .sh files."; exit 0; fi
+          shellcheck --severity=error "${files[@]}"
+      - name: Run PSScriptAnalyzer on *.ps1
+        shell: pwsh
+        run: |
+          Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser -SkipPublisherCheck
+          $files = Get-ChildItem -Recurse -Include *.ps1 -Path . |
+            Where-Object { $_.FullName -notmatch '[\\/]\.venv[\\/]|[\\/]\.git[\\/]|[\\/]\.terraform[\\/]' }
+          if (-not $files) { Write-Host "No .ps1 files to scan."; exit 0 }
+          $issues = $files | ForEach-Object {
+            Invoke-ScriptAnalyzer -Path $_.FullName -Severity Error `
+              -ExcludeRule PSAvoidUsingWriteHost,PSUseDeclaredVarsMoreThanAssignments
+          }
+          if ($issues) { $issues | Format-Table -AutoSize; exit 1 } else { Write-Host "No errors." }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.6.0"
+          terraform_version: "1.10.0"
           terraform_wrapper: false
       - name: terraform fmt -check
         run: terraform fmt -check -recursive

--- a/infra-terraform/infra/main.tf
+++ b/infra-terraform/infra/main.tf
@@ -27,18 +27,18 @@ locals {
 
   # Resolve effective per-family models. If no family vars are set, route the
   # legacy model_name into its matching slot for back-compat.
-  any_family_set    = var.haiku_model != "" || var.sonnet_model != "" || var.opus_model != ""
-  legacy_lower      = lower(var.model_name)
-  legacy_is_haiku   = strcontains(local.legacy_lower, "haiku")
-  legacy_is_sonnet  = strcontains(local.legacy_lower, "sonnet")
-  legacy_is_opus    = strcontains(local.legacy_lower, "opus")
+  any_family_set   = var.haiku_model != "" || var.sonnet_model != "" || var.opus_model != ""
+  legacy_lower     = lower(var.model_name)
+  legacy_is_haiku  = strcontains(local.legacy_lower, "haiku")
+  legacy_is_sonnet = strcontains(local.legacy_lower, "sonnet")
+  legacy_is_opus   = strcontains(local.legacy_lower, "opus")
 
-  effective_haiku_model    = local.any_family_set ? var.haiku_model  : (local.legacy_is_haiku  ? var.model_name : "")
-  effective_sonnet_model   = local.any_family_set ? var.sonnet_model : (local.legacy_is_sonnet ? var.model_name : "")
-  effective_opus_model     = local.any_family_set ? var.opus_model   : (local.legacy_is_opus   ? var.model_name : "")
-  effective_haiku_capacity  = local.any_family_set ? tonumber(var.haiku_capacity)  : tonumber(var.model_capacity)
+  effective_haiku_model     = local.any_family_set ? var.haiku_model : (local.legacy_is_haiku ? var.model_name : "")
+  effective_sonnet_model    = local.any_family_set ? var.sonnet_model : (local.legacy_is_sonnet ? var.model_name : "")
+  effective_opus_model      = local.any_family_set ? var.opus_model : (local.legacy_is_opus ? var.model_name : "")
+  effective_haiku_capacity  = local.any_family_set ? tonumber(var.haiku_capacity) : tonumber(var.model_capacity)
   effective_sonnet_capacity = local.any_family_set ? tonumber(var.sonnet_capacity) : tonumber(var.model_capacity)
-  effective_opus_capacity   = local.any_family_set ? tonumber(var.opus_capacity)   : tonumber(var.model_capacity)
+  effective_opus_capacity   = local.any_family_set ? tonumber(var.opus_capacity) : tonumber(var.model_capacity)
 }
 
 resource "random_string" "suffix" {


### PR DESCRIPTION
# Pull Request #6: CI workflow + Dependabot + issue/PR templates

## What

Adds the validation surface area the repo needs before going public:

- **`.github/workflows/validate.yml`** — runs on every PR + push to `main`. Four jobs in parallel:
  - `bicep` — installs Bicep CLI, runs `bicep build` + `bicep lint` on both `main.bicep` and `foundry.bicep`.
  - `terraform` — `terraform fmt -check -recursive`, `init -backend=false`, and `validate` on `infra-terraform/infra/`.
  - `python` — installs `requirements.txt` and byte-compiles every sample script in `src/`.
  - `shell` — `shellcheck --severity=error` on all `*.sh` (resolved via `git ls-files`) and PSScriptAnalyzer Error-level scan on all `*.ps1`.
- **`.github/dependabot.yml`** — weekly dependency PRs for pip (root), GitHub Actions, and Terraform providers in `infra-terraform/infra/`. Each ecosystem capped at 5 open PRs with scoped labels and commit prefixes.
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — structured bug-report form with required IaC variant / region / model / tool-versions / repro / expected / actual fields, plus required confirmations (searched duplicates, redacted IDs).
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — problem / solution / alternatives / scope.
- **`.github/ISSUE_TEMPLATE/config.yml`** — disables blank issues and pins three contact links (MSRC, Foundry docs, Claude SDK docs).
- **`.github/PULL_REQUEST_TEMPLATE.md`** — what / why / how / verification checklist with the IaC-parity and no-secrets reminders.

## Drive-by fix in this PR

- `terraform fmt -recursive` on `infra-terraform/infra/main.tf` — a few `local` blocks had misaligned `=` columns from an older edit. Pure whitespace, no semantic change. Verified `terraform validate` still passes.

## Verification

Ran each CI step locally against the current tree:

| Step | Result |
|---|---|
| `terraform fmt -check -recursive` | ✅ exit 0 after the fmt fix in this PR |
| `bicep build main.bicep` + `foundry.bicep` | ✅ exit 0 (3× `BCP037 modelProviderData` warnings — known type-metadata gap; the property is real and supported by the Cognitive Services RP) |
| `python -m compileall -q src/` | ✅ exit 0 |
| `PSScriptAnalyzer` Error-level on all `*.ps1` | ✅ no error-level findings |
| `shellcheck` | Not installed locally; will run in CI. Severity is `error` so cosmetic warnings won't break the build. |

## Non-changes

- No README changes.
- No new dependencies pulled into the runtime path.
- No source / IaC changes other than the cosmetic `tf fmt` pass.
- Repo metadata (visibility, description, topics, homepage, delete-branch-on-merge) was already set via the API in parallel with this PR.

## Follow-ups (out of scope for this PR)

- `awesome-azd` listing PR to `Azure/awesome-azd`.
- Optional `markdownlint-cli2` step on README + community files once we settle on a style config.
