### PR TITLE
Rename README title to 'The Claude on Foundry Starter Kit'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Claude on Microsoft Foundry — Starter
+# The Claude on Foundry Starter Kit
 
 > Short link: **<https://aka.ms/claude/start>**
 


### PR DESCRIPTION
Small naming tweak: the H1 now reads **The Claude on Foundry Starter Kit** to match how the repo is referred to elsewhere. No content changes.