### PR TITLE
Add dev container for Codespaces support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+    "name": "Azure Search OpenAI Demo",
+    "image": "mcr.microsoft.com/devcontainers/python:3.13-bookworm",
+    "features": {
+        "ghcr.io/devcontainers/features/node:1": {
+            // This should match the version of Node.js in Github Actions workflows
+            "version": "22",
+            "nodeGypDependencies": false
+        },
+        "ghcr.io/devcontainers/features/azure-cli:1.2.5": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/azure/azure-dev/azd:latest": {}
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-azuretools.azure-dev",
+                "ms-azuretools.vscode-bicep",
+                "ms-python.python",
+                "astral-sh.ty",
+                "esbenp.prettier-vscode",
+                "DavidAnson.vscode-markdownlint"
+            ]
+        }
+    },
+    "forwardPorts": [
+        50505
+    ],
+    "postCreateCommand": "",
+    "remoteUser": "vscode",
+    "hostRequirements": {
+        "memory": "8gb"
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,8 @@
 {
-    "name": "Azure Search OpenAI Demo",
+    "name": "The Claude on Foundry Starter Kit",
     "image": "mcr.microsoft.com/devcontainers/python:3.13-bookworm",
     "features": {
-        "ghcr.io/devcontainers/features/node:1": {
-            // This should match the version of Node.js in Github Actions workflows
-            "version": "22",
-            "nodeGypDependencies": false
-        },
         "ghcr.io/devcontainers/features/azure-cli:1.2.5": {},
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         "ghcr.io/azure/azure-dev/azd:latest": {}
     },
     "customizations": {
@@ -16,19 +10,9 @@
             "extensions": [
                 "ms-azuretools.azure-dev",
                 "ms-azuretools.vscode-bicep",
-                "ms-python.python",
-                "astral-sh.ty",
-                "esbenp.prettier-vscode",
-                "DavidAnson.vscode-markdownlint"
+                "ms-python.python"
             ]
         }
     },
-    "forwardPorts": [
-        50505
-    ],
-    "postCreateCommand": "",
-    "remoteUser": "vscode",
-    "hostRequirements": {
-        "memory": "8gb"
-    }
+    "remoteUser": "vscode"
 }


### PR DESCRIPTION
## What

Add a dev container so the repo opens cleanly in GitHub Codespaces / VS Code Dev Containers with `az`, `azd`, and Python preinstalled.

## Why

Lets new users try the starter kit without installing the Azure CLI, Azure Developer CLI, or Python toolchain locally — one click "Open in Codespaces" and `azd up` works.

## How

Adds devcontainer.json based on the `mcr.microsoft.com/devcontainers/python:3.13-bookworm` image with:
- `azure-cli` and `azure-dev/azd` dev container features
- VS Code extensions: `ms-azuretools.azure-dev`, `ms-azuretools.vscode-bicep`, `ms-python.python`

## Verification

Built and opened the dev container; `az`, `azd`, and `python3` are on `PATH`. No infra or runtime code changed.

- [ ] `azd up` succeeded end-to-end on a fresh env (Bicep)
- [ ] `azd up` succeeded end-to-end on a fresh env (Terraform)
- [ ] `python src/hello_claude.py` returned a live model response
- [x] N/A — docs-only / CI-only change

## Checklist

- [x] Mirrored the change across **both** infra-bicep and infra-terraform (if applicable) — N/A, no IaC changes
- [x] No secrets / subscription IDs / tenant IDs / object IDs in commits, comments, or PR body
- [ ] README updated if user-facing behavior changed — N/A
- [x] Conventional one logical change per PR