### PR TITLE
Dev container: add git-lfs feature to silence post-checkout warning

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
     "image": "mcr.microsoft.com/devcontainers/python:3.13-bookworm",
     "features": {
         "ghcr.io/devcontainers/features/azure-cli:1.2.5": {},
-        "ghcr.io/azure/azure-dev/azd:latest": {}
+        "ghcr.io/azure/azure-dev/azd:latest": {},
+        "ghcr.io/devcontainers/features/git-lfs:1": {}
     },
     "customizations": {
         "vscode": {


### PR DESCRIPTION
## What

Add the `git-lfs` dev container feature so the binary is on `PATH` inside Codespaces / Dev Containers.

## Why

In any environment where `git lfs install --system` has been run on the host (which is the case for the default Codespaces image), git copies a `post-checkout` hook into every new clone. That hook expects `git-lfs` on `PATH`. The dev container image (`mcr.microsoft.com/devcontainers/python:3.13-bookworm`) doesn't ship `git-lfs`, so every `git checkout` / `git switch` / `git restore` prints:

```
This repository is configured for Git LFS but 'git-lfs' was not found on your path.
If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout'
file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').
```

Repo itself does **not** use LFS (no `.gitattributes`, no `filter.lfs` config, no `core.hookspath`) — the warning is purely cosmetic, but it fires on every git operation and looks like a real problem to new users.

Deleting `.git/hooks/post-checkout` works once but the hook comes back on every fresh Codespace / container rebuild. Installing the `git-lfs` binary inside the container is the only fix that survives rebuilds.

## How

One new entry under `features`:

```json
"ghcr.io/devcontainers/features/git-lfs:1": {}
```

Adds ~5 s to the first container build and a few MB to the image. No runtime impact.

## Verification

- [x] N/A — docs / CI-only change (`.devcontainer/devcontainer.json` only)
- [ ] Built the container; `git lfs version` returns a version; `git checkout` no longer prints the warning

## Checklist

- [x] Mirrored across both infra-bicep and infra-terraform if applicable — N/A
- [x] No secrets in commits, comments, or PR body
- [x] README updated if user-facing behavior changed — N/A (silent quality-of-life fix)
- [x] One logical change per PR
